### PR TITLE
Support spawning multiple threads / cluster module

### DIFF
--- a/bin/colyseus-loadtest
+++ b/bin/colyseus-loadtest
@@ -3,6 +3,7 @@ const path = require('path');
 
 require('ts-node').register({
   ignore: [],
+  transpileOnly: true, /* do not typecheck everything */
   project: path.resolve(__dirname, '..',  'tsconfig.json')
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/loadtest",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Utility tool for load testing Colyseus.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@colyseus/loadtest",
-  "version": "0.14.4-alpha.0",
+  "version": "0.14.4-alpha.2",
   "description": "Utility tool for load testing Colyseus.",
   "main": "index.js",
   "scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,50 @@
+import path from "path";
+import os from "os";
+
+export function getArguments() {
+    const argv = require('minimist')(process.argv.slice(2));
+    const packageJson = require(__dirname + "/../package.json");
+
+    if (argv.help) {
+        console.log(`${packageJson.name} v${packageJson.version}
+
+Options:
+    --endpoint: WebSocket endpoint for all connections (default: ws://localhost:2567)
+    --room: room handler name
+    --numClients: number of connections to open
+    [--delay]: delay to start each connection (in milliseconds)
+    [--project]: specify a tsconfig.json file path
+    [--threads]: number of threads to distribute clients
+
+Example:
+    colyseus-loadtest example/bot.ts --endpoint ws://localhost:2567 --room state_handler`);
+        process.exit();
+    }
+
+    const endpoint = argv.endpoint || `ws://localhost:2567`;
+    const roomName = argv.room;
+    const numClients = argv.numClients || 1;
+    const scriptFile = path.resolve(argv._[0]);
+    const delay = argv.delay || 0;
+    const threads = Math.max(1, argv.threads || os.cpus().length);
+    if (!scriptFile) {
+        console.error("you must specify a scripting file.");
+        process.exit();
+    }
+    const scripting = require(scriptFile);
+
+    if (!roomName) {
+        console.error("--room options is required.");
+        process.exit();
+    }
+
+    return {
+        endpoint,
+        roomName,
+        numClients,
+        delay,
+        scripting,
+        threads,
+    };
+}
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,12 +23,15 @@ Example:
 
     const endpoint = argv.endpoint || `ws://localhost:2567`;
     const roomName = argv.room;
-    const numClients = argv.numClients || 1;
     const scriptFile = path.resolve(argv._[0]);
     const delay = argv.delay || 0;
+
+    // Distribute provided numClients to threads
     const threads = (argv.threads === 'all')
         ? os.cpus().length
         : argv.threads || 1;
+
+    const numClients = Math.max(1, Math.ceil((argv.numClients || 1) / threads));
 
     if (!scriptFile) {
         console.error("you must specify a scripting file.");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ Example:
     const numClients = argv.numClients || 1;
     const scriptFile = path.resolve(argv._[0]);
     const delay = argv.delay || 0;
-    const threads = (argv.threads === 'max')
+    const threads = (argv.threads === 'all')
         ? os.cpus().length
         : argv.threads || 1;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,10 @@ Example:
     const numClients = argv.numClients || 1;
     const scriptFile = path.resolve(argv._[0]);
     const delay = argv.delay || 0;
-    const threads = Math.max(1, argv.threads || os.cpus().length);
+    const threads = (argv.threads === 'max')
+        ? os.cpus().length
+        : argv.threads || 1;
+
     if (!scriptFile) {
         console.error("you must specify a scripting file.");
         process.exit();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,325 +1,167 @@
-import * as path from "path";
-import * as util from "util";
-import * as blessed from "blessed";
+import cluster from "cluster";
 import { Client, Room } from "colyseus.js";
 
-const argv = require('minimist')(process.argv.slice(2));
+import { WorkerStats } from "./types";
+import { getArguments } from "./cli";
+import * as rendering from "./rendering";
+import { debounce } from "./utils";
 
-const packageJson = require(__dirname + "/../package.json");
+let {
+    endpoint,
+    roomName,
+    numClients,
+    delay,
+    scripting,
+    threads,
+} = getArguments();
 
-if (argv.help) {
-    console.log(`${packageJson.name} v${packageJson.version}
+if (cluster.isMaster) {
+    //
+    // The master process only renders data received from forks.
+    //
+    rendering.setup(endpoint, roomName, numClients * threads);
 
-Options:
-    --endpoint: WebSocket endpoint for all connections (default: ws://localhost:2567)
-    --room: room handler name
-    --numClients: number of connections to open
-    [--delay]: delay to start each connection (in milliseconds)
-    [--project]: specify a tsconfig.json file path
+    let workers: {[id: string]: WorkerStats} = {};
 
-Example:
-    colyseus-loadtest example/bot.ts --endpoint ws://localhost:2567 --room state_handler`);
-    process.exit();
-}
+    const updateStats = debounce((message: any) => {
+        const [workerId, stats] = message;
+        workers[workerId] = stats;
 
-const endpoint = argv.endpoint || `ws://localhost:2567`;
-const roomName = argv.room;
-const numClients = argv.numClients || 1;
-const scriptFile = path.resolve(argv._[0]);
-const delay = argv.delay || 0;
-if (!scriptFile) {
-    console.error("you must specify a scripting file.");
-    process.exit();
-}
-const scripting = require(scriptFile);
-const connections: Room[] = [];
+        // re-evaluate totals
+        const totalStats = { bytesReceived: 0, bytesSent: 0, clientsConnected: 0 };
 
-if (!roomName) {
-    console.error("--room options is required.");
-    process.exit();
-}
-
-const screen = blessed.screen({ smartCSR: true });
-
-const headerBox = blessed.box({
-    label: ` ⚔  ${packageJson.name} ${packageJson.version} ⚔  `,
-    top: 0,
-    left: 0,
-    width: "70%",
-    height: 'shrink',
-    children: [
-        blessed.text({ top: 1, left: 1, tags: true, content: `{yellow-fg}endpoint:{/yellow-fg} ${endpoint}` }),
-        blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}room:{/yellow-fg} ${roomName}` }),
-        blessed.text({ top: 3, left: 1, tags: true, content: `{yellow-fg}serialization method:{/yellow-fg} ...` }),
-        blessed.text({ top: 4, left: 1, tags: true, content: `{yellow-fg}time elapsed:{/yellow-fg} ...` }),
-    ],
-    border: { type: 'line' },
-    style: {
-        label: { fg: 'cyan' },
-        border: { fg: 'green' }
-    }
-})
-
-
-let clientsConnected = 0;
-let clientsFailed = 0;
-
-const successfulConnectionBox = blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}connected:{/yellow-fg} ${clientsConnected}` });
-const failedConnectionBox = blessed.text({ top: 3, left: 1, tags: true, content: `{yellow-fg}failed:{/yellow-fg} ${clientsFailed}` });
-
-const clientsBox = blessed.box({
-    label: ' clients ',
-    left: "70%",
-    width: "30%",
-    height: 'shrink',
-    children: [
-        blessed.text({ top: 1, left: 1, tags: true, content: `{yellow-fg}numClients:{/yellow-fg} ${numClients}` }),
-        successfulConnectionBox,
-        failedConnectionBox
-    ],
-    border: { type: 'line' },
-    tags: true,
-    style: {
-        label: { fg: 'cyan' },
-        border: { fg: 'green' },
-    }
-})
-
-const processingBox = blessed.box({
-    label: ' processing ',
-    top: 6,
-    left: "70%",
-    width: "30%",
-    height: 'shrink',
-    border: { type: 'line' },
-    children: [
-        blessed.text({ top: 1, left: 1, tags: true, content: `{yellow-fg}memory:{/yellow-fg} ...` }),
-        blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}cpu:{/yellow-fg} ...` }),
-        // blessed.text({ top: 1, left: 1, content: `memory: ${process.memoryUsage().heapUsed} / ${process.memoryUsage().heapTotal}` })
-    ],
-    tags: true,
-    style: {
-        label: { fg: 'cyan' },
-        border: { fg: 'green' },
-    }
-});
-
-const networkingBox = blessed.box({
-    label: ' networking ',
-    top: 11,
-    left: "70%",
-    width: "30%",
-    border: { type: 'line' },
-    children: [
-        blessed.text({ top: 1, left: 1, tags: true, content: `{yellow-fg}bytes received:{/yellow-fg} ...` }),
-        blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}bytes sent:{/yellow-fg} ...` }),
-        // blessed.text({ top: 1, left: 1, content: `memory: ${process.memoryUsage().heapUsed} / ${process.memoryUsage().heapTotal}` })
-    ],
-    tags: true,
-    style: {
-        label: { fg: 'cyan' },
-        border: { fg: 'green' },
-    }
-});
-
-const logBox = blessed.box({
-    label: ' logs ',
-    top: 7,
-    width: "70%",
-    padding: 1,
-    border: { type: 'line' },
-    tags: true,
-    style: {
-        label: { fg: 'cyan' },
-        border: { fg: 'green' },
-    },
-    // scroll
-    scrollable: true,
-    input: true,
-    alwaysScroll: true,
-    scrollbar: {
-        style: {
-            bg: "green"
-        },
-        track: {
-            bg: "gray"
+        for (let workerId in workers) {
+            totalStats.bytesReceived += workers[workerId].bytesReceived;
+            totalStats.bytesSent += workers[workerId].bytesSent;
+            totalStats.clientsConnected += workers[workerId].clientsConnected;
         }
-    },
-    keys: true,
-    vi: true,
-    mouse: true
-});
 
-screen.key(['escape', 'q', 'C-c'], (ch, key) => process.exit(0)); // Quit on Escape, q, or Control-C.
-screen.title = "@colyseus/loadtest";
-screen.append(headerBox);
-screen.append(clientsBox);
-screen.append(logBox);
-screen.append(processingBox);
-screen.append(networkingBox);
-screen.render();
+        rendering.render(totalStats);
+    }, 250);
 
-console.log = function(...args) {
-    logBox.content = args.map(arg => util.inspect(arg)).join(" ") + "\n" + logBox.content;
-    screen.render();
-}
-console.warn = function(...args) {
-    logBox.content = `{yellow-fg}${args.map(arg => util.inspect(arg)).join(" ")}{/yellow-fg}\n${logBox.content}`;
-    screen.render();
-}
+    const onMasterReceivedMessage = (payload: any) => {
+        // console.log("RECEIVED MESSAGE!", payload);
 
-const error = console.error;
-console.error = function(...args) {
-    logBox.content = `{red-fg}${args.map(arg => util.inspect(arg)).join(" ")}{/red-fg}\n${logBox.content}`;
-    screen.render();
-}
+        switch (payload.type) {
+            case "console":
+                console[payload.method](...payload.args);
+                break;
 
-process.on("uncaughtException", (e) => {
-    error(e);
-    process.exit();
-});
+            case "error":
+                rendering.error(payload.message)
+                break;
 
-function formatBytes (bytes) {
-    if (bytes < 1024) {
-        return `${bytes} b`;
+            case "updateSerializer":
+                rendering.updateSerializer(payload.message)
+                break;
 
-    } else if (bytes < Math.pow(1024, 2)) {
-        return `${(bytes / 1024).toFixed(2)} kb`;
-
-    } else if (bytes < Math.pow(1024, 4)) {
-        return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
-    }
-}
-
-function elapsedTime(inputSeconds) {
-    const days = Math.floor(inputSeconds / (60 * 60 * 24));
-    const hours = Math.floor((inputSeconds % (60 * 60 * 24)) / (60 * 60));
-    const minutes = Math.floor(((inputSeconds % (60 * 60 * 24)) % (60 * 60)) / 60);
-    const seconds = Math.floor(((inputSeconds % (60 * 60 * 24)) % (60 * 60)) % 60);
-
-    let ddhhmmss = '';
-
-    if (days > 0) { ddhhmmss += days + ' day '; }
-    if (hours > 0) { ddhhmmss += hours + ' hour '; }
-    if (minutes > 0) { ddhhmmss += minutes + ' minutes '; }
-    if (seconds > 0) { ddhhmmss += seconds + ' seconds '; }
-
-    return ddhhmmss || "...";
-}
-
-/**
- * Update memory / cpu usage
- */
-const loadTestStartTime = Date.now();
-let startTime = process.hrtime()
-let startUsage = process.cpuUsage()
-let bytesReceived: number = 0;
-let bytesSent: number = 0;
-setInterval(() => {
-    /**
-     * Program elapsed time
-     */
-    const elapsedTimeText = (headerBox.children[3] as blessed.Widgets.TextElement);
-    elapsedTimeText.content = `{yellow-fg}time elapsed:{/yellow-fg} ${elapsedTime(Math.round((Date.now() - loadTestStartTime) / 1000))}`;
-
-    /**
-     * Memory / CPU Usage
-     */
-    const memoryText = (processingBox.children[0] as blessed.Widgets.TextElement);
-    memoryText.content = `{yellow-fg}memory:{/yellow-fg} ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2)} MB`;
-
-    var elapTime = process.hrtime(startTime)
-    var elapUsage = process.cpuUsage(startUsage)
-
-    var elapTimeMS = elapTime[0] * 1000 + elapTime[1] / 1000000;
-    var elapUserMS = elapUsage.user / 1000;
-    var elapSystMS = elapUsage.system / 1000;
-    var cpuPercent = (100 * (elapUserMS + elapSystMS) / elapTimeMS).toFixed(1);
-
-    const cpuText = (processingBox.children[1] as blessed.Widgets.TextElement);
-    cpuText.content = `{yellow-fg}cpu:{/yellow-fg} ${cpuPercent}%`;
-
-    screen.render();
-
-    startTime = process.hrtime()
-    startUsage = process.cpuUsage()
-
-    /**
-     * Networking
-     */
-    const bytesReceivedBox = (networkingBox.children[0] as blessed.Widgets.TextElement);
-    bytesReceivedBox.content = `{yellow-fg}bytes received:{/yellow-fg} ${formatBytes(bytesReceived)}`
-
-    const bytesSentBox = (networkingBox.children[1] as blessed.Widgets.TextElement);
-    bytesSentBox.content = `{yellow-fg}bytes sent:{/yellow-fg} ${formatBytes(bytesSent)}`
-}, 1000);
-
-function handleError (message) {
-    console.error(message);
-    clientsFailed++;
-    failedConnectionBox.content = `{red-fg}failed:{/red-fg} ${clientsFailed}`;
-    screen.render();
-}
-
-(async () => {
-    for (let i = 0; i < numClients; i++) {
-        const client = new Client(endpoint);
-
-        const options = (typeof(scripting.requestJoinOptions) === "function")
-            ? await scripting.requestJoinOptions.call(client, i)
-            : {};
-
-        client.joinOrCreate(roomName, options).then(room => {
-            connections.push(room);
-
-            // display serialization method in the UI
-            const serializerIdText = (headerBox.children[2] as blessed.Widgets.TextElement);
-            serializerIdText.content = `{yellow-fg}serialization method:{/yellow-fg} ${room.serializerId}`;
-
-            room.connection.ws.addEventListener('message', (event) => {
-                bytesReceived += new Uint8Array(event.data).length;
-            });
-
-            // overwrite original send function to trap sent bytes.
-            const _send = room.connection.ws.send;
-            room.connection.ws.send = function (data: ArrayBuffer) {
-                bytesSent += data.byteLength;
-                _send.call(room.connection.ws, data);
-            }
-
-            clientsConnected++;
-            successfulConnectionBox.content = `{yellow-fg}connected:{/yellow-fg} ${clientsConnected}`;
-            screen.render();
-
-            room.onError.once(handleError);
-
-            room.onLeave.once(() => {
-                clientsConnected--;
-                successfulConnectionBox.content = `{yellow-fg}connected:{/yellow-fg} ${clientsConnected}`;
-                screen.render();
-            });
-
-            if (scripting.onJoin) {
-                scripting.onJoin.call(room);
-            }
-
-            if (scripting.onLeave) {
-                room.onLeave(scripting.onLeave.bind(room));
-            }
-
-            if (scripting.onError) {
-                room.onError(scripting.onError.bind(room));
-            }
-
-            if (scripting.onStateChange) {
-                room.onStateChange(scripting.onStateChange.bind(room));
-            }
-        }).catch((err) => {
-            handleError(err);
-        });
-
-        if (delay > 0) {
-          await (new Promise(resolve => setTimeout(resolve, delay)));
+            case "stats":
+                updateStats(payload.message);
+                break;
         }
     }
-})();
+
+    // create forks
+    for (let i = 0; i < threads; i++) {
+        const forked = cluster.fork();
+        forked.process.on("message", onMasterReceivedMessage);
+        workers[cluster.fork().id] = { bytesReceived: 0, bytesSent: 0, clientsConnected: 0 };
+    }
+
+} else {
+    //
+    // Each fork process is going to spawn `numClients`
+    //
+    const connections: Room[] = [];
+
+    const stats: WorkerStats = {
+        bytesReceived: 0,
+        bytesSent: 0,
+        clientsConnected: 0
+    };
+
+    const handleError = (message) =>
+        process.send({ type: "error", message });
+
+    const updateSerializer = (serializerId) =>
+        process.send({ type: "updateSerializer", message: serializerId });
+
+    const updateClientsConnected = () => {};
+        // process.send({ type: "clientsConnected", message: stats.clientsConnected });
+
+    // update stats at every second
+    setInterval(() =>
+        process.send({ type: "stats", message: [process.pid, stats] }), 1000);
+
+    // Trap console methods to forward message to master process
+    console.log = (...args: any[]) =>
+        process.send({ type: "console", method: "log", args });
+
+    console.warn = (...args: any[]) =>
+        process.send({ type: "console", method: "warn", args });
+
+    console.error = (...args: any[]) =>
+        process.send({ type: "console", method: "error", args });
+
+    (async () => {
+        for (let i = 0; i < numClients; i++) {
+            const client = new Client(endpoint);
+
+            const options = (typeof (scripting.requestJoinOptions) === "function")
+                ? await scripting.requestJoinOptions.call(client, i)
+                : {};
+
+            client.joinOrCreate(roomName, options).then(room => {
+                connections.push(room);
+
+                updateSerializer(room.serializerId);
+
+                room.connection.ws.addEventListener('message', (event) => {
+                    stats.bytesReceived += new Uint8Array(event.data).length;
+                });
+
+                // overwrite original send function to trap sent bytes.
+                const _send = room.connection.ws.send;
+                room.connection.ws.send = function (data: ArrayBuffer) {
+                    stats.bytesSent += data.byteLength;
+                    _send.call(room.connection.ws, data);
+                }
+
+                stats.clientsConnected++;
+                updateClientsConnected();
+
+                room.onError.once(handleError);
+
+                room.onLeave.once(() => {
+                    stats.clientsConnected--;
+                    updateClientsConnected();
+                });
+
+                if (scripting.onJoin) {
+                    scripting.onJoin.call(room);
+                }
+
+                if (scripting.onLeave) {
+                    room.onLeave(scripting.onLeave.bind(room));
+                }
+
+                if (scripting.onError) {
+                    room.onError(scripting.onError.bind(room));
+                }
+
+                if (scripting.onStateChange) {
+                    room.onStateChange(scripting.onStateChange.bind(room));
+                }
+            }).catch((err) => {
+                handleError(err);
+            });
+
+            if (delay > 0) {
+                await (new Promise(resolve => setTimeout(resolve, delay)));
+            }
+        }
+    })();
+
+}
+
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ if (cluster.isMaster) {
     for (let i = 0; i < threads; i++) {
         const forked = cluster.fork();
         forked.process.on("message", onMasterReceivedMessage);
-        workers[cluster.fork().id] = { bytesReceived: 0, bytesSent: 0, clientsConnected: 0 };
+        workers[forked.id] = { bytesReceived: 0, bytesSent: 0, clientsConnected: 0 };
     }
 
 } else {
@@ -109,9 +109,9 @@ if (cluster.isMaster) {
         process.send({ type: "console", method: "error", args });
 
     (async () => {
-        for (let i = 0; i < numClients; i++) {
-            const client = new Client(endpoint);
+        const client = new Client(endpoint);
 
+        for (let i = 0; i < numClients; i++) {
             const options = (typeof (scripting.requestJoinOptions) === "function")
                 ? await scripting.requestJoinOptions.call(client, i)
                 : {};
@@ -158,6 +158,7 @@ if (cluster.isMaster) {
                 if (scripting.onStateChange) {
                     room.onStateChange(scripting.onStateChange.bind(room));
                 }
+
             }).catch((err) => {
                 handleError(err);
             });

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,8 @@ if (cluster.isMaster) {
         clientsConnected: 0
     };
 
-    const handleError = (message) =>
-        process.send({ type: "error", message });
+    const handleError = (error) =>
+        process.send({ type: "error", message: { code: error.code, message: error.message } });
 
     const updateSerializer = (serializerId) =>
         process.send({ type: "updateSerializer", message: serializerId });

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -1,0 +1,234 @@
+import util from "util";
+import blessed from "blessed";
+
+import { elapsedTime, formatBytes, throttle } from "./utils";
+import { WorkerStats } from "./types";
+
+const packageJson = require(__dirname + "/../package.json");
+
+const RENDER_THROTTLE_MS = 100; // re-render the screen only each 100ms to avoid consuming too much CPU
+
+let screen: blessed.Widgets.Screen;
+let headerBox: blessed.Widgets.BoxElement;
+let clientsBox: blessed.Widgets.BoxElement; 
+let processingBox: blessed.Widgets.BoxElement; 
+let networkingBox: blessed.Widgets.BoxElement; 
+let logBox: blessed.Widgets.BoxElement; 
+
+let successfulConnectionBox: blessed.Widgets.TextElement;
+let failedConnectionBox: blessed.Widgets.TextElement;
+
+let clientsConnected = 0;
+let clientsFailed = 0;
+
+let loadTestStartTime = Date.now();
+
+const renderThrottled = throttle(() =>
+    screen.render(), RENDER_THROTTLE_MS);
+
+export function setup(endpoint: string, roomName: string, numClients: number) {
+    screen = blessed.screen({ smartCSR: true });
+
+    headerBox = blessed.box({
+        label: ` ⚔  ${packageJson.name} ${packageJson.version} ⚔  `,
+        top: 0,
+        left: 0,
+        width: "70%",
+        height: 'shrink',
+        children: [
+            blessed.text({ top: 1, left: 1, tags: true, content: `{yellow-fg}endpoint:{/yellow-fg} ${endpoint}` }),
+            blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}room:{/yellow-fg} ${roomName}` }),
+            blessed.text({ top: 3, left: 1, tags: true, content: `{yellow-fg}serialization method:{/yellow-fg} ...` }),
+            blessed.text({ top: 4, left: 1, tags: true, content: `{yellow-fg}time elapsed:{/yellow-fg} ...` }),
+        ],
+        border: { type: 'line' },
+        style: {
+            label: { fg: 'cyan' },
+            border: { fg: 'green' }
+        }
+    });
+
+    successfulConnectionBox = blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}connected:{/yellow-fg} ${clientsConnected}` });
+    failedConnectionBox = blessed.text({ top: 3, left: 1, tags: true, content: `{yellow-fg}failed:{/yellow-fg} ${clientsFailed}` });
+
+    clientsBox = blessed.box({
+        label: ' clients ',
+        left: "70%",
+        width: "30%",
+        height: 'shrink',
+        children: [
+            blessed.text({ top: 1, left: 1, tags: true, content: `{yellow-fg}numClients:{/yellow-fg} ${numClients}` }),
+            successfulConnectionBox,
+            failedConnectionBox
+        ],
+        border: { type: 'line' },
+        tags: true,
+        style: {
+            label: { fg: 'cyan' },
+            border: { fg: 'green' },
+        }
+    })
+
+    processingBox = blessed.box({
+        label: ' processing ',
+        top: 6,
+        left: "70%",
+        width: "30%",
+        height: 'shrink',
+        border: { type: 'line' },
+        children: [
+            blessed.text({ top: 1, left: 1, tags: true, content: `{yellow-fg}memory:{/yellow-fg} ...` }),
+            blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}cpu:{/yellow-fg} ...` }),
+            // blessed.text({ top: 1, left: 1, content: `memory: ${process.memoryUsage().heapUsed} / ${process.memoryUsage().heapTotal}` })
+        ],
+        tags: true,
+        style: {
+            label: { fg: 'cyan' },
+            border: { fg: 'green' },
+        }
+    });
+
+    networkingBox = blessed.box({
+        label: ' networking ',
+        top: 11,
+        left: "70%",
+        width: "30%",
+        border: { type: 'line' },
+        children: [
+            blessed.text({ top: 1, left: 1, tags: true, content: `{yellow-fg}bytes received:{/yellow-fg} ...` }),
+            blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}bytes sent:{/yellow-fg} ...` }),
+            // blessed.text({ top: 1, left: 1, content: `memory: ${process.memoryUsage().heapUsed} / ${process.memoryUsage().heapTotal}` })
+        ],
+        tags: true,
+        style: {
+            label: { fg: 'cyan' },
+            border: { fg: 'green' },
+        }
+    });
+
+    logBox = blessed.box({
+        label: ' logs ',
+        top: 7,
+        width: "70%",
+        padding: 1,
+        border: { type: 'line' },
+        tags: true,
+        style: {
+            label: { fg: 'cyan' },
+            border: { fg: 'green' },
+        },
+        // scroll
+        scrollable: true,
+        input: true,
+        alwaysScroll: true,
+        scrollbar: {
+            style: {
+                bg: "green"
+            },
+            track: {
+                bg: "gray"
+            }
+        },
+        keys: true,
+        vi: true,
+        mouse: true
+    });
+
+    // Trap built-in console log methods.
+    console.log = function (...args) {
+        logBox.content = args.map(arg => util.inspect(arg)).join(" ") + "\n" + logBox.content;
+        renderThrottled();
+    };
+
+    console.warn = function (...args) {
+        logBox.content = `{yellow-fg}${args.map(arg => util.inspect(arg)).join(" ")}{/yellow-fg}\n${logBox.content}`;
+        renderThrottled();
+    };
+
+    const error = console.error;
+    console.error = function (...args) {
+        logBox.content = `{red-fg}${args.map(arg => util.inspect(arg)).join(" ")}{/red-fg}\n${logBox.content}`;
+        renderThrottled();
+    };
+
+    process.on("uncaughtException", (e) => {
+        error(e);
+        process.exit();
+    });
+
+    // append widgets to the screen.
+    screen.key(['escape', 'q', 'C-c'], (ch, key) => process.exit(0)); // Quit on Escape, q, or Control-C.
+    screen.title = "@colyseus/loadtest";
+    screen.append(headerBox);
+    screen.append(clientsBox);
+    screen.append(logBox);
+    screen.append(processingBox);
+    screen.append(networkingBox);
+    screen.render();
+}
+
+/**
+ * Update memory / cpu usage
+ */
+let startTime = process.hrtime()
+let startUsage = process.cpuUsage()
+
+export function render(stats: WorkerStats) {
+    /**
+     * Program elapsed time
+     */
+    const elapsedTimeText = (headerBox.children[3] as blessed.Widgets.TextElement);
+    elapsedTimeText.content = `{yellow-fg}time elapsed:{/yellow-fg} ${elapsedTime(Math.round((Date.now() - loadTestStartTime) / 1000))}`;
+
+    /**
+     * Memory / CPU Usage
+     */
+    const memoryText = (processingBox.children[0] as blessed.Widgets.TextElement);
+    memoryText.content = `{yellow-fg}memory:{/yellow-fg} ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2)} MB`;
+
+    var elapTime = process.hrtime(startTime)
+    var elapUsage = process.cpuUsage(startUsage)
+
+    var elapTimeMS = elapTime[0] * 1000 + elapTime[1] / 1000000;
+    var elapUserMS = elapUsage.user / 1000;
+    var elapSystMS = elapUsage.system / 1000;
+    var cpuPercent = (100 * (elapUserMS + elapSystMS) / elapTimeMS).toFixed(1);
+
+    const cpuText = (processingBox.children[1] as blessed.Widgets.TextElement);
+    cpuText.content = `{yellow-fg}cpu:{/yellow-fg} ${cpuPercent}%`;
+
+    renderThrottled();
+
+    startTime = process.hrtime()
+    startUsage = process.cpuUsage()
+
+    /**
+     * Networking
+     */
+    const bytesReceivedBox = (networkingBox.children[0] as blessed.Widgets.TextElement);
+    bytesReceivedBox.content = `{yellow-fg}bytes received:{/yellow-fg} ${formatBytes(stats.bytesReceived)}`
+
+    const bytesSentBox = (networkingBox.children[1] as blessed.Widgets.TextElement);
+    bytesSentBox.content = `{yellow-fg}bytes sent:{/yellow-fg} ${formatBytes(stats.bytesSent)}`
+
+    updateClientsConnected(stats.clientsConnected);
+}
+
+export function updateSerializer(serializerId) {
+    // display serialization method in the UI
+    const serializerIdText = (headerBox.children[2] as blessed.Widgets.TextElement);
+    serializerIdText.content = `{yellow-fg}serialization method:{/yellow-fg} ${serializerId}`;
+}
+
+export function updateClientsConnected(clientsConnected) {
+    successfulConnectionBox.content = `{yellow-fg}connected:{/yellow-fg} ${clientsConnected}`;
+    renderThrottled();
+}
+
+export function error (message) {
+    console.error(message);
+    clientsFailed++;
+    console.log({clientsFailed})
+    failedConnectionBox.content = `{red-fg}failed:{/red-fg} ${clientsFailed}`;
+    renderThrottled();
+}

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -18,7 +18,6 @@ let logBox: blessed.Widgets.BoxElement;
 let successfulConnectionBox: blessed.Widgets.TextElement;
 let failedConnectionBox: blessed.Widgets.TextElement;
 
-let clientsConnected = 0;
 let clientsFailed = 0;
 
 let loadTestStartTime = Date.now();
@@ -48,8 +47,8 @@ export function setup(endpoint: string, roomName: string, numClients: number) {
         }
     });
 
-    successfulConnectionBox = blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}connected:{/yellow-fg} ${clientsConnected}` });
-    failedConnectionBox = blessed.text({ top: 3, left: 1, tags: true, content: `{yellow-fg}failed:{/yellow-fg} ${clientsFailed}` });
+    successfulConnectionBox = blessed.text({ top: 2, left: 1, tags: true, content: `{yellow-fg}connected:{/yellow-fg} 0` });
+    failedConnectionBox = blessed.text({ top: 3, left: 1, tags: true, content: `{yellow-fg}failed:{/yellow-fg} 0` });
 
     clientsBox = blessed.box({
         label: ' clients ',
@@ -145,16 +144,10 @@ export function setup(endpoint: string, roomName: string, numClients: number) {
         renderThrottled();
     };
 
-    const error = console.error;
     console.error = function (...args) {
         logBox.content = `{red-fg}${args.map(arg => util.inspect(arg)).join(" ")}{/red-fg}\n${logBox.content}`;
         renderThrottled();
     };
-
-    process.on("uncaughtException", (e) => {
-        error(e);
-        process.exit();
-    });
 
     // append widgets to the screen.
     screen.key(['escape', 'q', 'C-c'], (ch, key) => process.exit(0)); // Quit on Escape, q, or Control-C.
@@ -165,6 +158,10 @@ export function setup(endpoint: string, roomName: string, numClients: number) {
     screen.append(processingBox);
     screen.append(networkingBox);
     screen.render();
+}
+
+export function destroy() {
+    screen.destroy();
 }
 
 /**
@@ -228,7 +225,6 @@ export function updateClientsConnected(clientsConnected) {
 export function error (message) {
     console.error(message);
     clientsFailed++;
-    console.log({clientsFailed})
     failedConnectionBox.content = `{red-fg}failed:{/red-fg} ${clientsFailed}`;
     renderThrottled();
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+export interface WorkerStats {
+    bytesReceived: number;
+    bytesSent: number;
+    clientsConnected: number;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,60 @@
+export function formatBytes(bytes: number) {
+    if (bytes < 1024) {
+        return `${bytes} b`;
+
+    } else if (bytes < Math.pow(1024, 2)) {
+        return `${(bytes / 1024).toFixed(2)} kb`;
+
+    } else if (bytes < Math.pow(1024, 4)) {
+        return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+    }
+}
+
+export function elapsedTime(inputSeconds: number) {
+    const days = Math.floor(inputSeconds / (60 * 60 * 24));
+    const hours = Math.floor((inputSeconds % (60 * 60 * 24)) / (60 * 60));
+    const minutes = Math.floor(((inputSeconds % (60 * 60 * 24)) % (60 * 60)) / 60);
+    const seconds = Math.floor(((inputSeconds % (60 * 60 * 24)) % (60 * 60)) % 60);
+
+    let ddhhmmss = '';
+
+    if (days > 0) { ddhhmmss += days + ' day '; }
+    if (hours > 0) { ddhhmmss += hours + ' hour '; }
+    if (minutes > 0) { ddhhmmss += minutes + ' minutes '; }
+    if (seconds > 0) { ddhhmmss += seconds + ' seconds '; }
+
+    return ddhhmmss || "...";
+}
+
+export function debounce<T extends Function>(cb: T, wait = 100) {
+    let h: any = 0;
+    let callable = (...args: any) => {
+        clearTimeout(h);
+        h = setTimeout(() => cb(...args), wait);
+    };
+    return <T>(<any>callable);
+}
+
+export function throttle<F extends (...args: any[]) => any>(func: F, waitFor: number) {
+    const now = () => new Date().getTime()
+    const resetStartTime = () => startTime = now()
+    let timeout: any;
+    let startTime: number = now() - waitFor;
+
+    return (...args: Parameters<F>): Promise<ReturnType<F>> =>
+        new Promise((resolve) => {
+            const timeLeft = (startTime + waitFor) - now()
+            if (timeout) {
+                clearTimeout(timeout)
+            }
+            if (startTime + waitFor <= now()) {
+                resetStartTime()
+                resolve(func(...args))
+            } else {
+                timeout = setTimeout(() => {
+                    resetStartTime()
+                    resolve(func(...args))
+                }, timeLeft)
+            }
+        })
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "declaration": true,
         "noImplicitAny": false,
         "sourceMap": false,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
     },


### PR DESCRIPTION
This PR adds multi-threading support via `--threads` option, values accepted are either a number or `all` to use all threads available. If `--threads` is not provided, only 1 is used.

The total number of clients spawned is going to be `--numClients` multiplied by `--threads`
(Example: `--numClients 200 --threads 4` = 800 connections) 

This wasn't thoroughly tested yet; needs testing on Windows!